### PR TITLE
Fix missing passthrough, inconsistent track extra idxs, and improve customization handling for tnp nano

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1712,6 +1712,9 @@ class ConfigBuilder(object):
         self.loadDefaultOrSpecifiedCFF(sequence,self.USERNANODefaultCFF)
         self.scheduleSequence(sequence.split('.')[-1],'nanoAOD_step')
 
+        if sequence in ["nanotpSequence", "nanotpSequenceMC"]:
+            self._options.customisation_file.append("PhysicsTools/NanoAOD/nanoTP_cff.customizeNANOTP")
+
     def prepare_EI(self, sequence = None):
         ''' Enrich the schedule with event interpretation '''
         from Configuration.StandardSequences.EventInterpretation import EventInterpretation

--- a/PhysicsTools/NanoAOD/python/nanoTP_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoTP_cff.py
@@ -59,6 +59,9 @@ def customizeNANOTP(process):
     finalMuons.src = "slimmedMuonsUpdated"
     finalLooseMuons.src = "slimmedMuonsUpdated"
 
+    # disable rekeying of track extra references since this breaks matching between standalone muon tracks and muon objects
+    process.slimmedMuons.trackExtraAssocs = cms.VInputTag()
+
     muonTable.src = "linkedMuons"
     muonTable.variables = cms.PSet(muonTable.variables,
             standaloneExtraIdx = Var('? standAloneMuon().isNonnull() ? standAloneMuon().extra().key() : -99', 'int', precision=-1, doc='Index of the innerTrack TrackExtra in the original collection'),


### PR DESCRIPTION
This should fix the inconsistencies in the standalone muon track <-> muon matching.