### PR TITLE
Update track refit to v722

### DIFF
--- a/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerBase.cc
+++ b/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerBase.cc
@@ -136,6 +136,8 @@ ResidualGlobalCorrectionMakerBase::ResidualGlobalCorrectionMakerBase(const edm::
   doRes_ = iConfig.getParameter<bool>("doRes");
   useIdealGeometry_ = iConfig.getParameter<bool>("useIdealGeometry");
   corFiles_ = iConfig.getParameter<std::vector<std::string>>("corFiles");
+  fieldlabel_ = iConfig.getParameter<std::string>("MagneticFieldLabel");
+
 
   inputBs_ = consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
 
@@ -347,7 +349,7 @@ ResidualGlobalCorrectionMakerBase::beginRun(edm::Run const& run, edm::EventSetup
 //   const MagneticField* field = thePropagator->magneticField();
 
   edm::ESHandle<MagneticField> magfield;
-  es.get<IdealMagneticFieldRecord>().get(magfield);
+  es.get<IdealMagneticFieldRecord>().get(fieldlabel_, magfield);
   auto field = magfield.product();
   
   std::set<std::pair<int, DetId> > parmset;

--- a/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerBase.h
+++ b/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerBase.h
@@ -262,6 +262,9 @@ protected:
   
   
   std::vector<std::string> corFiles_;
+
+  std::string fieldlabel_;
+
   
 //   SiStripClusterInfo siStripClusterInfo_;
 

--- a/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerTwoTrackG4e.cc
+++ b/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerTwoTrackG4e.cc
@@ -882,6 +882,12 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
       bool valid = true;
       
       
+      if (false) {
+        const GlobalPoint fieldrefpoint(itrack->vertex().x(), itrack->vertex().y(), itrack->vertex().z());
+        auto const fieldvalref = field->inTesla(fieldrefpoint);
+        std::cout << "refpos: " << fieldrefpoint << " bfield = " << fieldvalref << std::endl;
+      }
+
       const unsigned int nicons = doMassConstraint_ ? 2 : 1;
 //       const unsigned int nicons = doMassConstraint_ ? 3 : 1;
       
@@ -912,6 +918,7 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
         
         if (kinTree->isEmpty() || !kinTree->isConsistent()) {
 //           continue;
+          std::cout << "Abort: invalid kinematic fit!\n";
           valid = false;
           break;
         }

--- a/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerTwoTrackG4e.cc
+++ b/Analysis/HitAnalyzer/plugins/ResidualGlobalCorrectionMakerTwoTrackG4e.cc
@@ -141,12 +141,16 @@ private:
   float Muminusgen_pt;
   float Muminusgen_eta;
   float Muminusgen_phi;
+
+  float Muplusgen_dr;
+  float Muminusgen_dr;
   
   std::array<float, 3> Muplus_refParms;
   std::array<float, 3> Muminus_refParms;
   
   std::vector<float> Muplus_jacRef;
   std::vector<float> Muminus_jacRef;
+  std::vector<float> Jpsi_jacMass;
   
   unsigned int Muplus_nhits;
   unsigned int Muplus_nvalid;
@@ -308,6 +312,9 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::beginStream(edm::StreamID streami
     tree->Branch("Muminusgen_pt", &Muminusgen_pt);
     tree->Branch("Muminusgen_eta", &Muminusgen_eta);
     tree->Branch("Muminusgen_phi", &Muminusgen_phi);
+
+    tree->Branch("Muplusgen_dr", &Muplusgen_dr);
+    tree->Branch("Muminusgen_dr", &Muminusgen_dr);
     
     tree->Branch("Muplus_refParms", Muplus_refParms.data(), "Muplus_refParms[3]/F");
     tree->Branch("Muminus_refParms", Muminus_refParms.data(), "Muminus_refParms[3]/F");
@@ -315,6 +322,7 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::beginStream(edm::StreamID streami
     if (fillJac_) {
       tree->Branch("Muplus_jacRef", &Muplus_jacRef);
       tree->Branch("Muminus_jacRef", &Muminus_jacRef);
+      tree->Branch("Jpsi_jacMass", &Jpsi_jacMass);
     }
     
     tree->Branch("Muplus_nhits", &Muplus_nhits);
@@ -535,6 +543,7 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
     }
     
     const reco::Candidate *mu0gen = nullptr;
+    double drmin0 = 0.1;
     if (doGen_ && !doSim_) {
       for (auto const &genpart : *genPartCollection) {
         if (genpart.status() != 1) {
@@ -544,9 +553,10 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
           continue;
         }
         
-        float dR0 = deltaR(genpart, *itrack);
-        if (dR0 < 0.1 && genpart.charge() == itrack->charge()) {
+        const double dR0 = deltaR(genpart, *itrack);
+        if (dR0 < drmin0 && genpart.charge() == itrack->charge()) {
           mu0gen = &genpart;
+          drmin0 = dR0;
         }
       }
     }
@@ -585,6 +595,7 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
       
 
       const reco::Candidate *mu1gen = nullptr;
+      double drmin1 = 0.1;
       
       double massconstraintval = massConstraint_;
       if (doGen_ && !doSim_) {
@@ -596,9 +607,10 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
             continue;
           }
           
-          float dR1 = deltaR(genpart, *jtrack);
-          if (dR1 < 0.1 && genpart.charge() == jtrack->charge()) {
+          const double dR1 = deltaR(genpart, *jtrack);
+          if (dR1 < drmin1 && genpart.charge() == jtrack->charge()) {
             mu1gen = &genpart;
+            drmin1 = dR1;
           }
         }
         
@@ -2202,7 +2214,13 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
           const reco::Candidate *muplusgen = nullptr;
           const reco::Candidate *muminusgen = nullptr;
           
+          Muplusgen_dr = -99.;
+          Muminusgen_dr = -99.;
+
           if (doGen_) {
+            double drminplus = 0.1;
+            double drminminus = 0.1;
+
             for (auto const &genpart : *genPartCollection) {
               if (genpart.status() != 1) {
                 continue;
@@ -2210,19 +2228,30 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
               if (std::abs(genpart.pdgId()) != 13) {
                 continue;
               }
-              
+
 //               float dRplus = deltaR(genpart.phi(), muarr[idxplus].phi(), genpart.eta(), muarr[idxplus].eta());
-              float dRplus = deltaR(genpart, muarr[idxplus]);
-              if (dRplus < 0.1 && genpart.charge() > 0) {
+              const double dRplus = deltaR(genpart, muarr[idxplus]);
+              if (dRplus < drminplus && genpart.charge() > 0) {
                 muplusgen = &genpart;
+                drminplus = dRplus;
               }
-              
+
 //               float dRminus = deltaR(genpart.phi(), muarr[idxminus].phi(), genpart.eta(), muarr[idxminus].eta());
-              float dRminus = deltaR(genpart, muarr[idxminus]);
-              if (dRminus < 0.1 && genpart.charge() < 0) {
+              const double dRminus = deltaR(genpart, muarr[idxminus]);
+              if (dRminus < drminminus && genpart.charge() < 0) {
                 muminusgen = &genpart;
+                drminminus = dRminus;
               }
             }
+
+            if (muplusgen != nullptr) {
+              Muplusgen_dr = drminplus;
+            }
+
+            if (muminusgen != nullptr) {
+              Muminusgen_dr = drminminus;
+            }
+
           }
           
           if (muplusgen != nullptr) {
@@ -2456,6 +2485,12 @@ void ResidualGlobalCorrectionMakerTwoTrackG4e::produce(edm::Event &iEvent, const
 
           Muminus_jacRef.resize(3*nparsfinal);
           Map<Matrix<float, 3, Dynamic, RowMajor>>(Muminus_jacRef.data(), 3, nparsfinal) = dxdparms.block(0, trackstateidxminus, nparsfinal, 3).transpose().cast<float>();
+
+          const Matrix<double, 1, 6> mjacalt = massJacobianAltD(refftsarr[0], refftsarr[1], mmu);
+
+          Jpsi_jacMass.resize(nparsfinal);
+          Map<Matrix<float, 1, Dynamic, RowMajor>>(Jpsi_jacMass.data(), 1, nparsfinal) = (mjacalt*dxdparms.leftCols<6>().transpose()).cast<float>();
+
 
           if (false) {
             std::cout << "Muplus pt eta phi = " << Muplus_pt << "  " << Muplus_eta << " " << Muplus_phi << std::endl;

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
@@ -29,5 +29,8 @@ public:
   SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelTemplateDBObjectESProducer() override;
   std::shared_ptr<const SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
+
+private:
+  std::string fieldlabel_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
@@ -21,6 +21,7 @@
 using namespace edm;
 
 SiPixelTemplateDBObjectESProducer::SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig) {
+	fieldlabel_ = iConfig.getParameter<std::string>("MagneticFieldLabel");
 	setWhatProduced(this);
 }
 
@@ -34,7 +35,7 @@ SiPixelTemplateDBObjectESProducer::~SiPixelTemplateDBObjectESProducer(){
 std::shared_ptr<const SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(const SiPixelTemplateDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
-	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
+	iRecord.getRecord<IdealMagneticFieldRecord>().get(fieldlabel_, magfield);
 
 	GlobalPoint center(0.0, 0.0, 0.0);
 	float theMagField = magfield.product()->inTesla(center).mag();

--- a/CalibTracker/SiPixelESProducers/python/SiPixelTemplateDBObjectESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelTemplateDBObjectESProducer_cfi.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelTemplateDBObjectESProducer = cms.ESProducer("SiPixelTemplateDBObjectESProducer")
+siPixelTemplateDBObjectESProducer = cms.ESProducer("SiPixelTemplateDBObjectESProducer",
+                                                      MagneticFieldLabel = cms.string(""),
+                                                   )
  

--- a/MagneticField/ParametrizedEngine/BuildFile.xml
+++ b/MagneticField/ParametrizedEngine/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags CXXFLAGS="-fno-tree-vectorize"/>
 <use   name="DataFormats/GeometryVector"/>
 <!--use   name="FWCore/Framework"/-->
 <use   name="FWCore/ParameterSet"/>

--- a/MagneticField/ParametrizedEngine/src/PolyFit3DParametrizedMagneticField.cc
+++ b/MagneticField/ParametrizedEngine/src/PolyFit3DParametrizedMagneticField.cc
@@ -63,7 +63,7 @@ PolyFit3DParametrizedMagneticField::inTesla(const GlobalPoint& gp) const {
   if (isDefined(gp)) {
     return inTeslaUnchecked(gp);
   } else {
-    edm::LogWarning("MagneticField|FieldOutsideValidity") << " Point " << gp << " is outside the validity region of PolyFit3DParametrizedMagneticField";
+    // edm::LogWarning("MagneticField|FieldOutsideValidity") << " Point " << gp << " is outside the validity region of PolyFit3DParametrizedMagneticField";
     return GlobalVector();
   }
 }

--- a/MagneticField/ParametrizedEngine/src/poly2d_base.cc
+++ b/MagneticField/ParametrizedEngine/src/poly2d_base.cc
@@ -33,8 +33,8 @@ void poly2d_term::Print(std::ostream &out, bool first_term)
 /////////////////////////////////////////////////////////////////////////////////
 
 //_______________________________________________________________________________
-double     poly2d_base::rval   = 0.; //Last values of r and z used
-double     poly2d_base::zval   = 0.;
+double     poly2d_base::rval   = std::numeric_limits<double>::infinity(); //Last values of r and z used
+double     poly2d_base::zval   = std::numeric_limits<double>::infinity();
 
 double   **poly2d_base::rz_pow = nullptr;  //table with calculated r^n*z^m values
 unsigned   poly2d_base::NTab   = 0;  //rz_pow table size
@@ -57,7 +57,7 @@ poly2d_base::~poly2d_base()
          delete [] rz_pow;
       }
       rz_pow = nullptr;
-      rval = zval = 0.;
+      rval = zval = std::numeric_limits<double>::infinity();
       NPwr = 0;
       NTab = 0;
       rz_set = false;
@@ -81,7 +81,7 @@ void poly2d_base::SetTabSize(const unsigned N)
    for (jr = 1, dN = N; jr < N; ++jr, --dN) {
       rz_pow[jr] = rz_pow[jr-1] + dN;
    }
-   rval = zval = 0.;
+   rval = zval = std::numeric_limits<double>::infinity();
    NTab = N;
 }
 

--- a/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
+++ b/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
@@ -12,7 +12,7 @@ using namespace magfieldparam;
 
 //_______________________________________________________________________________
 unsigned rz_harm_poly::Cnt    = 0;      //Number of the "rz_harm_poly" objects
-double   rz_harm_poly::phival = -11111.;//Last phi value used
+double   rz_harm_poly::phival = std::numeric_limits<double>::infinity();//Last phi value used
 bool     rz_harm_poly::phi_set = false; //TRUE if phi value is set
 unsigned rz_harm_poly::MaxM   = 0;      //Max. M among "rz_harm_poly" objects
 
@@ -63,7 +63,7 @@ rz_harm_poly::~rz_harm_poly()
       TrigArr = nullptr;
       TASize = 0;
       MaxM = 0;
-      phival = -11111.;
+      phival = std::numeric_limits<double>::infinity();
       phi_set = false;
    }
 }

--- a/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
+++ b/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
@@ -115,6 +115,8 @@ void rz_harm_poly::FillTrigArr(const double phi)
    if (!TrigArr) return;
    trig_pair tp(phi);
    TrigArr[1] = tp;
+   // FIXME this loop will be auto-vectorized in slc7_amd64_gcc700 with default
+   // compiler flags and gives incorrect results
    for (unsigned jp = 2; jp <= MaxM; ++jp) TrigArr[jp] = TrigArr[jp-1].Add(tp);
 }
 

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -144,6 +144,7 @@ trackrefit = cms.EDProducer('ResidualGlobalCorrectionMakerG4e',
                                    applyHitQuality = cms.bool(True),
                                    useIdealGeometry = cms.bool(False),
                                    corFiles = cms.vstring(),
+                                   MagneticFieldLabel = cms.string(""),
 )
 
 trackrefitideal = cms.EDProducer('ResidualGlobalCorrectionMakerG4e',
@@ -165,6 +166,7 @@ trackrefitideal = cms.EDProducer('ResidualGlobalCorrectionMakerG4e',
                                    applyHitQuality = cms.bool(True),
                                    useIdealGeometry = cms.bool(True),
                                    corFiles = cms.vstring(),
+                                   MagneticFieldLabel = cms.string(""),
 )
 
 mergedGlobalIdxs = cms.EDProducer("GlobalIdxProducer",

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -451,12 +451,18 @@ def nanoAOD_customizeData(process):
                                     ),
                                 )
 
-    # load 3d field map and use it for g4e propagator
+    # load 3d field map and use it for g4e propagator, geant4 internals via geometry producer and a few other places related to the track refit
     from MagneticField.ParametrizedEngine.parametrizedMagneticField_PolyFit3D_cfi import ParametrizedMagneticFieldProducer as PolyFit3DMagneticFieldProducer
     process.PolyFit3DMagneticFieldProducer = PolyFit3DMagneticFieldProducer
     fieldlabel = "PolyFit3DMf"
     process.PolyFit3DMagneticFieldProducer.label = fieldlabel
+    process.geopro.MagneticFieldLabel = fieldlabel
     process.Geant4ePropagator.MagneticFieldLabel = fieldlabel
+    process.stripCPEESProducer.MagneticFieldLabel = fieldlabel
+    process.StripCPEfromTrackAngleESProducer.MagneticFieldLabel = fieldlabel
+    process.siPixelTemplateDBObjectESProducer.MagneticFieldLabel = fieldlabel
+    process.templates.MagneticFieldLabel = fieldlabel
+    process.trackrefit.MagneticFieldLabel = fieldlabel
 
     return process
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
@@ -15,6 +15,7 @@ class  PixelCPETemplateRecoESProducer: public edm::ESProducer{
  private:
   edm::ParameterSet pset_;
   bool DoLorentz_;
+  std::string fieldlabel_;
 };
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -27,6 +27,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
   DoLorentz_ = p.existsAs<bool>("DoLorentz")?p.getParameter<bool>("DoLorentz"):false;
 
   pset_ = p;
+  fieldlabel_ = p.getParameter<std::string>("MagneticFieldLabel");
   setWhatProduced(this,myname);
 
   //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
@@ -39,7 +40,7 @@ std::unique_ptr<PixelClusterParameterEstimator>
 PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
-  iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield );
+  iRecord.getRecord<IdealMagneticFieldRecord>().get(fieldlabel_, magfield );
 
   edm::ESHandle<TrackerGeometry> pDD;
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -15,7 +15,8 @@ templates = cms.ESProducer("PixelCPETemplateRecoESProducer",
     # True in Run II for offline RECO
     DoLorentz = cms.bool(True),
  
-    LoadTemplatesFromDB = cms.bool(True)
+    LoadTemplatesFromDB = cms.bool(True),
+    MagneticFieldLabel = cms.string(""),
 
 )
 

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
@@ -30,6 +30,7 @@ StripCPEESProducer::StripCPEESProducer(const edm::ParameterSet & p)
 
   cpeNum = enumMap[type];
   parametersPSet = (p.exists("parameters") ? p.getParameter<edm::ParameterSet>("parameters") : p);
+  fieldlabel = p.getParameter<std::string>("MagneticFieldLabel");
   setWhatProduced(this,name);
 }
 
@@ -37,7 +38,7 @@ std::unique_ptr<StripClusterParameterEstimator> StripCPEESProducer::
 produce(const TkStripCPERecord & iRecord) 
 { 
   edm::ESHandle<TrackerGeometry> pDD;  iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );
-  edm::ESHandle<MagneticField> magfield;  iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield );
+  edm::ESHandle<MagneticField> magfield;  iRecord.getRecord<IdealMagneticFieldRecord>().get(fieldlabel, magfield );
   edm::ESHandle<SiStripLorentzAngle> lorentzAngle;   iRecord.getRecord<SiStripLorentzAngleDepRcd>().get(lorentzAngle);
   edm::ESHandle<SiStripBackPlaneCorrection> backPlaneCorrection; iRecord.getRecord<SiStripBackPlaneCorrectionDepRcd>().get(backPlaneCorrection);
   edm::ESHandle<SiStripConfObject> confObj;  iRecord.getRecord<SiStripConfObjectRcd>().get(confObj);

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.h
@@ -25,6 +25,7 @@ class  StripCPEESProducer: public edm::ESProducer {
 
   CPE_t cpeNum;
   edm::ParameterSet parametersPSet;
+  std::string fieldlabel;
 
 };
 #endif

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEESProducer_cfi.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 stripCPEESProducer = cms.ESProducer("StripCPEESProducer",
                                     ComponentName = cms.string('stripCPE'),
                                     ComponentType = cms.string('SimpleStripCPE'),
-                                    parameters    = cms.PSet()
+                                    parameters    = cms.PSet(),
+                                    MagneticFieldLabel = cms.string(""),
 )

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -47,6 +47,7 @@ private:
   void updateMagneticField(edm::EventSetup const &es);
 
   G4RunManagerKernel *m_kernel;
+  std::string m_fieldlabel;
   edm::ParameterSet m_pField;
   SimActivityRegistry m_registry;
   std::vector<std::shared_ptr<SimWatcher>> m_watchers;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -59,6 +59,7 @@ static void createWatchers(const edm::ParameterSet &iP,
 
 GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     : m_kernel(nullptr),
+      m_fieldlabel(p.getParameter<std::string>("MagneticFieldLabel")),
       m_pField(p.getParameter<edm::ParameterSet>("MagneticField")),
       m_attach(nullptr),
       m_p(p),
@@ -84,7 +85,7 @@ void GeometryProducer::updateMagneticField(edm::EventSetup const &es) {
   if (m_pUseMagneticField) {
     // setup the magnetic field
     edm::ESHandle<MagneticField> pMF;
-    es.get<IdealMagneticFieldRecord>().get(pMF);
+    es.get<IdealMagneticFieldRecord>().get(m_fieldlabel, pMF);
     const GlobalPoint g(0., 0., 0.);
     edm::LogInfo("GeometryProducer") << "B-field(T) at (0,0,0)(cm): " << pMF->inTesla(g);
 

--- a/TrackPropagation/Geant4e/python/geantRefit_cff.py
+++ b/TrackPropagation/Geant4e/python/geantRefit_cff.py
@@ -10,6 +10,7 @@ from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 geopro = cms.EDProducer("GeometryProducer",
      UseMagneticField = cms.bool(True),
      UseSensitiveDetectors = cms.bool(False),
+     MagneticFieldLabel = cms.string(""),
      MagneticField = cms.PSet(
          UseLocalMagFieldManager = cms.bool(False),
          Verbosity = cms.untracked.bool(False),

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
@@ -15,6 +15,7 @@ TransientTrackBuilderESProducer::TransientTrackBuilderESProducer(const edm::Para
 {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
+  fieldlabel_ = p.getParameter<std::string>("MagneticFieldLabel");
   setWhatProduced(this,myname);
 }
 
@@ -24,7 +25,7 @@ std::unique_ptr<TransientTrackBuilder>
 TransientTrackBuilderESProducer::produce(const TransientTrackRecord & iRecord){ 
 
   edm::ESHandle<MagneticField> magfield;
-  iRecord.getRecord<IdealMagneticFieldRecord>().get( magfield );     
+  iRecord.getRecord<IdealMagneticFieldRecord>().get(fieldlabel_, magfield );
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   iRecord.getRecord<GlobalTrackingGeometryRecord>().get(theTrackingGeometry); 
 

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
@@ -17,6 +17,7 @@ class  TransientTrackBuilderESProducer: public edm::ESProducer{
   std::unique_ptr<TransientTrackBuilder> produce(const TransientTrackRecord &);
  private:
   edm::ParameterSet pset_;
+  std::string fieldlabel_;
 };
 
 

--- a/TrackingTools/TransientTrack/python/TransientTrackBuilder_cfi.py
+++ b/TrackingTools/TransientTrack/python/TransientTrackBuilder_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 TransientTrackBuilderESProducer = cms.ESProducer("TransientTrackBuilderESProducer",
-    ComponentName = cms.string('TransientTrackBuilder')
+    ComponentName = cms.string('TransientTrackBuilder'),
+    MagneticFieldLabel = cms.string(""),
 )
 
 


### PR DESCRIPTION
Differences with respect to previous version v718 are

-some extra debugging info and improved gen matching for the two track fit (no impact on nano production)

-fixed configuration for 3d field map so that it is consistently used in all parts of the track refit for data
(previously an inconsistent mix of the two field maps was being used in different places, and most egregiously between the geant propagation and the analytic jacobians, which could bias and/or degrade the resolution of both track parameters and layer by layer corrections)

-technical fixes to 3d field map to avoid inconsistent or undefined behaviour and avoid excessive LogWarnings (which can also lead to large memory consumption with some monitoring/logging options)