### PR TITLE
Low PU ECAL energy correction fix and TnP update

### DIFF
--- a/PhysicsTools/NanoAOD/python/electronTP_LowPU_cff.py
+++ b/PhysicsTools/NanoAOD/python/electronTP_LowPU_cff.py
@@ -1,0 +1,161 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.globals_cff import *
+from PhysicsTools.NanoAOD.electrons_cff import *
+from PhysicsTools.NanoAOD.genparticles_cff import *
+from PhysicsTools.NanoAOD.particlelevel_cff import *
+from PhysicsTools.NanoAOD.genWeights_cff import *
+from PhysicsTools.NanoAOD.genVertex_cff import *
+from PhysicsTools.NanoAOD.vertices_cff import *
+from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
+from PhysicsTools.PatAlgos.slimming.miniAOD_tools import *
+
+# for electron ID
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+from RecoEgamma.ElectronIdentification.ElectronMVAValueMapProducer_cfi import *
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import EleMVA_WP, EleMVARaw_WP
+
+egmGsfElectronIDsNano = cms.EDProducer(
+        "VersionedGsfElectronIdProducer",
+        physicsObjectSrc = cms.InputTag('slimmedElectronsUpdated'),
+        physicsObjectIDs = cms.VPSet()
+)
+electronMVAValueMapProducerNano = electronMVAValueMapProducer.clone()
+electronMVAValueMapProducerNano.src = cms.InputTag("gedGsfElectrons", processName=cms.InputTag.skipCurrentProcess())
+#electronMVAValueMapProducerNano.src = cms.InputTag("gedGsfElectronsFrom94XTo106X")
+electronMVAValueMapProducerNano.srcMiniAOD = "slimmedElectronsUpdated"
+
+egmGsfElectronIDTaskNano = cms.Task(
+        electronMVAValueMapProducerNano,
+        egmGsfElectronIDsNano
+)
+egmGsfElectronIDSequenceNano = cms.Sequence(egmGsfElectronIDTaskNano)
+
+electron_id_modules_WorkingPoints_nanoAOD.modules = cms.vstring(
+    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
+    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff', 
+)
+electron_id_modules_WorkingPoints_nanoAOD.WorkingPoints = cms.vstring(
+    "egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-veto",
+    "egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-loose",
+    "egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-medium",
+    "egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-tight",
+)
+
+from copy import deepcopy
+for modname in electron_id_modules_WorkingPoints_nanoAOD.modules:
+        idmod= __import__(modname, globals(), locals(), ['idName','cutFlow'])
+        #print("mod name ", modname)
+        for name in dir(idmod):
+                item = getattr(idmod,name)
+                #print("item ", item)
+                if hasattr(item,'idName') and hasattr(item,'cutFlow'):
+                    #item = deepcopy(item)
+                    #if 'mva' in item.idName.value().lower():
+                    #    # change the MVA producer name to electronMVAValueMapProducerNano 
+                    #    item.cutFlow[0].mvaValueMapName = item.cutFlow[0].mvaValueMapName.value().replace("electronMVAValueMapProducer","electronMVAValueMapProducerNano")
+                    #    item.cutFlow[0].mvaCategoriesMapName = item.cutFlow[0].mvaCategoriesMapName.value().replace("electronMVAValueMapProducer","electronMVAValueMapProducerNano")
+                    setupVIDSelection(egmGsfElectronIDsNano, item)
+
+electronSequence_LowPU = electronSequence.copyAndExclude([slimmedElectronsTo106X])
+electronSequence_LowPU.insert(electronSequence_LowPU.index(bitmapVIDForEle), egmGsfElectronIDSequenceNano)
+
+slimmedElectronsWithUserData.userFloats = cms.PSet(
+    miniIsoChg = cms.InputTag("isoForEle:miniIsoChg"),
+    miniIsoAll = cms.InputTag("isoForEle:miniIsoAll"),
+    PFIsoChg = cms.InputTag("isoForEle:PFIsoChg"),
+    PFIsoAll = cms.InputTag("isoForEle:PFIsoAll"),
+    PFIsoAll04 = cms.InputTag("isoForEle:PFIsoAll04"),
+    ptRatio = cms.InputTag("ptRatioRelForEle:ptRatio"),
+    ptRel = cms.InputTag("ptRatioRelForEle:ptRel"),
+    jetNDauChargedMVASel = cms.InputTag("ptRatioRelForEle:jetNDauChargedMVASel"),
+    ecalTrkEnergyErrPostCorrNew = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyErrPostCorr"),
+    ecalTrkEnergyPreCorrNew     = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyPreCorr"),
+    ecalTrkEnergyPostCorrNew    = cms.InputTag("calibratedPatElectronsNano","ecalTrkEnergyPostCorr"),
+    energyScaleUpNew               = cms.InputTag("calibratedPatElectronsNano","energyScaleUp"),
+    energyScaleDownNew             = cms.InputTag("calibratedPatElectronsNano","energyScaleDown"),
+    energySigmaUpNew               = cms.InputTag("calibratedPatElectronsNano","energySigmaUp"),
+    energySigmaDownNew             = cms.InputTag("calibratedPatElectronsNano","energySigmaDown"),
+    ecalEnergyPreCorrNew        = cms.InputTag("calibratedPatElectronsNano","ecalEnergyPreCorr"),
+    ecalEnergyPostCorrNew       = cms.InputTag("calibratedPatElectronsNano","ecalEnergyPostCorr"),
+)
+
+slimmedElectronsWithUserData.userIntFromBools = cms.PSet(
+        cutbasedID_Fall17_V1_veto   = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V1-veto"),
+        cutbasedID_Fall17_V1_loose  = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V1-loose"),
+        cutbasedID_Fall17_V1_medium = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V1-medium"),
+        cutbasedID_Fall17_V1_tight  = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V1-tight"),
+        cutbasedID_Fall17_V2_veto   = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-veto"),
+        cutbasedID_Fall17_V2_loose  = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-loose"),
+        cutbasedID_Fall17_V2_medium = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-medium"),
+        cutbasedID_Fall17_V2_tight  = cms.InputTag("egmGsfElectronIDsNano:cutBasedElectronID-Fall17-94X-V2-tight"),
+        cutbasedID_HEEP             = cms.InputTag("egmGsfElectronIDsNano:heepElectronID-HEEPV70"),
+)
+
+linkedElectrons = cms.EDFilter("PATElectronSelector",
+    src = finalElectrons.src,
+    cut = finalElectrons.cut,
+)
+
+electronTable.src = "linkedElectrons"
+slimmedElectronsUpdated.src = cms.InputTag("slimmedElectrons")
+
+bitmapVIDForEle.WorkingPoints = electron_id_modules_WorkingPoints_nanoAOD.WorkingPoints
+bitmapVIDForEleHEEP.WorkingPoints = cms.vstring("egmGsfElectronIDsNano:heepElectronID-HEEPV70")
+
+## SC candidates
+superClusterMerger =  cms.EDProducer("EgammaSuperClusterMerger",
+    src = cms.VInputTag(cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel"),
+                        cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower"),
+#                        cms.InputTag("particleFlowEGamma"),
+                        ),
+)
+
+
+superClusterCands = cms.EDProducer("ConcreteEcalCandidateProducer",
+                                   src = cms.InputTag("superClusterMerger"),
+                                   particleType = cms.int32(11),
+                                   )
+
+goodSuperClusters = cms.EDFilter("RecoEcalCandidateRefSelector",
+                                 src = cms.InputTag("superClusterCands"),
+                                 cut = cms.string('abs(eta)<2.5 &&  et>5.0'),
+                                 filter = cms.bool(True)
+                                 )
+
+
+recoEcalCandidateHelper = cms.EDProducer("RecoEcalCandidateVariableHelper",
+                                         probes = cms.InputTag("superClusterCands"),
+                                         countTracks = cms.bool( False ),
+                                         trkIsoPtMin = cms.double( 0.5 ),
+                                         trkIsoStripEndcap = cms.double( 0.03 ),
+                                         trackProducer = cms.InputTag( "generalTracks" ),
+                                         trkIsoStripBarrel = cms.double( 0.03 ),
+                                         trkIsoConeSize = cms.double( 0.4 ),
+                                         trkIsoVetoConeSize = cms.double( 0.06 ),
+                                         trkIsoRSpan = cms.double( 999999.0 ),
+                                         trkIsoZSpan = cms.double( 999999. )
+                                         )
+
+electronSCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("goodSuperClusters"),
+    cut = cms.string(""),
+    name= cms.string("ElectronSC"),
+    doc = cms.string("superclusters associated to electrons"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the electrons
+    variables = cms.PSet(CandVars,
+    ),
+)
+sc_sequenceAOD = cms.Sequence(
+        superClusterMerger      +
+        superClusterCands       +
+        goodSuperClusters       +
+        electronSCTable
+)
+
+from PhysicsTools.NanoAOD.jets_cff import jetCorrFactorsNano,updatedJets
+electronTPSequence_LowPU = cms.Sequence(jetCorrFactorsNano + updatedJets + electronSequence_LowPU + linkedElectrons + electronTable + sc_sequenceAOD)
+electronTPSequenceMC_LowPU = cms.Sequence(jetCorrFactorsNano + updatedJets + electronSequence_LowPU + linkedElectrons + electronTable + mergedGenParticles + genParticles2HepMC + electronMC + sc_sequenceAOD)

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -199,14 +199,11 @@ for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2:
 run2_nanoAOD_102Xv1.toModify(calibratedPatElectronsNano,
     correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain_v2")
 )
-##############################end calibratedPatElectronsNano############################
-
 # use the dedicated electron energy and scale corrections
-calibratedPatElectronsLowPU = RecoEgamma.EgammaTools.calibratedEgammas_cff.calibratedPatElectrons.clone(
-    produceCalibratedObjs = False,
-    correctionFile = cms.string("PhysicsTools/NanoAOD/data/ScalesSmearings/Run2017_LowPU_v2"),
+run2_nanoAOD_LowPU.toModify(calibratedPatElectronsNano,
+    correctionFile = cms.string("PhysicsTools/NanoAOD/data/ScalesSmearings/Run2017_LowPU_v2")
 )
-run2_nanoAOD_LowPU.toModify(calibratedPatElectronsLowPU, src = "slimmedElectronsUpdated")
+##############################end calibratedPatElectronsNano############################
 
 slimmedElectronsWithUserData = cms.EDProducer("PATElectronUserDataEmbedder",
     src = cms.InputTag("slimmedElectrons"),
@@ -306,19 +303,6 @@ run2_miniAOD_80XLegacy.toModify(slimmedElectronsWithUserData.userFloats,
     mvaSpring16GP = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values"),
     mvaSpring16HZZ = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Values"),
 )
-
-run2_nanoAOD_LowPU.toModify(slimmedElectronsWithUserData.userFloats,
-    ecalTrkEnergyErrPostCorrNew = cms.InputTag("calibratedPatElectronsLowPU","ecalTrkEnergyErrPostCorr"),
-    ecalTrkEnergyPreCorrNew     = cms.InputTag("calibratedPatElectronsLowPU","ecalTrkEnergyPreCorr"),
-    ecalTrkEnergyPostCorrNew    = cms.InputTag("calibratedPatElectronsLowPU","ecalTrkEnergyPostCorr"),
-    ecalEnergyPreCorrNew        = cms.InputTag("calibratedPatElectronsLowPU","ecalEnergyPreCorr"),
-    ecalEnergyPostCorrNew       = cms.InputTag("calibratedPatElectronsLowPU","ecalEnergyPostCorr"),
-    energyScaleUpNew            = cms.InputTag("calibratedPatElectronsLowPU","energyScaleUp"),
-    energyScaleDownNew          = cms.InputTag("calibratedPatElectronsLowPU","energyScaleDown"),
-    energySigmaUpNew            = cms.InputTag("calibratedPatElectronsLowPU","energySigmaUp"),
-    energySigmaDownNew          = cms.InputTag("calibratedPatElectronsLowPU","energySigmaDown"),
-)
-
 
 run2_miniAOD_80XLegacy.toModify(slimmedElectronsWithUserData.userIntFromBools,
     mvaSpring16GP_WP90 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring16-GeneralPurpose-V1-wp90"),
@@ -460,6 +444,10 @@ for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_miniAOD
 #the94X miniAOD V2 had a bug in the scale and smearing for electrons in the E/p comb
 #therefore we redo it but but we need use a new name for the userFloat as we cant override existing userfloats
 # scale and smearing only when available#ONLY needed for this era
+run2_nanoAOD_LowPU.toModify(slimmedElectronsWithUserData.userFloats,
+    ecalEnergyPreCorrNew        = cms.InputTag("calibratedPatElectronsNano","ecalEnergyPreCorr"),
+    ecalEnergyPostCorrNew       = cms.InputTag("calibratedPatElectronsNano","ecalEnergyPostCorr"),
+)
 run2_nanoAOD_LowPU.toModify(electronTable.variables,
     ecalCorr = Var("userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')",float, doc="ratio of the calibrated ecal energy / miniaod ecal energy"),
     pfIso03_all = Var("userFloat('PFIsoAll')",float,doc="PF isolation dR=0.3, total (with rho*EA PU corrections)"),
@@ -590,7 +578,7 @@ electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matc
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCold)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
-for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:
+for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1,run2_nanoAOD_LowPU:
     modifier.toModify(bitmapVIDForEle, src = "slimmedElectronsUpdated")
     modifier.toModify(bitmapVIDForEleSpring15, src = "slimmedElectronsUpdated")
     modifier.toModify(bitmapVIDForEleSum16, src = "slimmedElectronsUpdated")
@@ -615,18 +603,16 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
 from RecoEgamma.ElectronIdentification.heepIdVarValueMapProducer_cfi import heepIDVarValueMaps
 _updateTo106X_sequence =cms.Sequence(heepIDVarValueMaps + slimmedElectronsTo106X)
 heepIDVarValueMaps.dataFormat = 2
-_withTo106XAndUpdate_sequence = cms.Sequence(_updateTo106X_sequence + slimmedElectronsUpdated + electronSequence.copy())
+#_withTo106XAndUpdate_sequence = cms.Sequence(_updateTo106X_sequence + slimmedElectronsUpdated + electronSequence.copy())
+# since slimmedElectronsUpdated is already added in line 612
+_withTo106XAndUpdate_sequence = cms.Sequence(_updateTo106X_sequence + electronSequence.copy())
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     _withTo106XAndUpdateAnd80XLegacyScale_sequence = _withTo106XAndUpdate_sequence.copy()
     _withTo106XAndUpdateAnd80XLegacyScale_sequence.replace(slimmedElectronsWithUserData, bitmapVIDForEleSpring15 +bitmapVIDForEleSum16 + slimmedElectronsWithUserData)
 
 _withTo106XAndUpdateAnd94XScale_sequence = _withTo106XAndUpdate_sequence.copy()
-for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1,run2_nanoAOD_LowPU:
     modifier.toReplaceWith(electronSequence, _withTo106XAndUpdate_sequence)
-
-_withTo106XAndUpdateAndLowPUScale_sequence = _withTo106XAndUpdate_sequence.copy()
-_withTo106XAndUpdateAndLowPUScale_sequence.replace(slimmedElectronsWithUserData, calibratedPatElectronsLowPU + slimmedElectronsWithUserData)
-run2_nanoAOD_LowPU.toReplaceWith(electronSequence, _withTo106XAndUpdateAndLowPUScale_sequence)
 
 electronSequence.replace(slimmedElectronsWithUserData,calibratedPatElectronsNano + slimmedElectronsWithUserData)

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -378,14 +378,14 @@ electronTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         eInvMinusPInv = Var("(1-eSuperClusterOverP())/ecalEnergy()",float,doc="1/E_SC - 1/p_trk",precision=10),
         scEtOverPt = Var("(superCluster().energy()/(pt*cosh(superCluster().eta())))-1",float,doc="(supercluster transverse energy)/pt-1",precision=8),
 
-        mvaFall17V2Iso = Var("userFloat('mvaFall17V2Iso')",float,doc="MVA Iso ID V2 score"),
-        mvaFall17V2Iso_WP80 = Var("userInt('mvaFall17V2Iso_WP80')",bool,doc="MVA Iso ID V2 WP80"),
-        mvaFall17V2Iso_WP90 = Var("userInt('mvaFall17V2Iso_WP90')",bool,doc="MVA Iso ID V2 WP90"),
-        mvaFall17V2Iso_WPL = Var("userInt('mvaFall17V2Iso_WPL')",bool,doc="MVA Iso ID V2 loose WP"),
-        mvaFall17V2noIso = Var("userFloat('mvaFall17V2noIso')",float,doc="MVA noIso ID V2 score"),
-        mvaFall17V2noIso_WP80 = Var("userInt('mvaFall17V2noIso_WP80')",bool,doc="MVA noIso ID V2 WP80"),
-        mvaFall17V2noIso_WP90 = Var("userInt('mvaFall17V2noIso_WP90')",bool,doc="MVA noIso ID V2 WP90"),
-        mvaFall17V2noIso_WPL = Var("userInt('mvaFall17V2noIso_WPL')",bool,doc="MVA noIso ID V2 loose WP"),
+        #mvaFall17V2Iso = Var("userFloat('mvaFall17V2Iso')",float,doc="MVA Iso ID V2 score"),
+        #mvaFall17V2Iso_WP80 = Var("userInt('mvaFall17V2Iso_WP80')",bool,doc="MVA Iso ID V2 WP80"),
+        #mvaFall17V2Iso_WP90 = Var("userInt('mvaFall17V2Iso_WP90')",bool,doc="MVA Iso ID V2 WP90"),
+        #mvaFall17V2Iso_WPL = Var("userInt('mvaFall17V2Iso_WPL')",bool,doc="MVA Iso ID V2 loose WP"),
+        #mvaFall17V2noIso = Var("userFloat('mvaFall17V2noIso')",float,doc="MVA noIso ID V2 score"),
+        #mvaFall17V2noIso_WP80 = Var("userInt('mvaFall17V2noIso_WP80')",bool,doc="MVA noIso ID V2 WP80"),
+        #mvaFall17V2noIso_WP90 = Var("userInt('mvaFall17V2noIso_WP90')",bool,doc="MVA noIso ID V2 WP90"),
+        #mvaFall17V2noIso_WPL = Var("userInt('mvaFall17V2noIso_WPL')",bool,doc="MVA noIso ID V2 loose WP"),
 
         cutBased = Var("userInt('cutbasedID_Fall17_V2_veto')+userInt('cutbasedID_Fall17_V2_loose')+userInt('cutbasedID_Fall17_V2_medium')+userInt('cutbasedID_Fall17_V2_tight')",int,doc="cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)"),
         vidNestedWPBitmap = Var("userInt('VIDNestedWPBitmap')",int,doc=_bitmapVIDForEle_docstring),
@@ -409,9 +409,9 @@ electronTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         seedGain = Var("userInt('seedGain')","uint8",doc="Gain of the seed crystal"),
         jetNDauCharged = Var("?userCand('jetForLepJetVar').isNonnull()?userFloat('jetNDauChargedMVASel'):0", "uint8", doc="number of charged daughters of the closest jet"),
     ),
-    externalVariables = cms.PSet(
-        mvaTTH = ExtVar(cms.InputTag("electronMVATTH"),float, doc="TTH MVA lepton ID score",precision=14),
-    ),
+    #externalVariables = cms.PSet(
+    #    mvaTTH = ExtVar(cms.InputTag("electronMVATTH"),float, doc="TTH MVA lepton ID score",precision=14),
+    #),
 )
 
 #the94X miniAOD V2 had a bug in the scale and smearing for electrons in the E/p comb
@@ -566,6 +566,7 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
+                        
 electronTables = cms.Sequence (electronMVATTH + electronTable)
 electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTable)
 electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
@@ -576,6 +577,7 @@ electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matc
                                                        objType=electronTable.name,
                                                        genparticles=None)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCold)
+
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1,run2_nanoAOD_LowPU:
@@ -611,7 +613,6 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     _withTo106XAndUpdateAnd80XLegacyScale_sequence = _withTo106XAndUpdate_sequence.copy()
     _withTo106XAndUpdateAnd80XLegacyScale_sequence.replace(slimmedElectronsWithUserData, bitmapVIDForEleSpring15 +bitmapVIDForEleSum16 + slimmedElectronsWithUserData)
 
-_withTo106XAndUpdateAnd94XScale_sequence = _withTo106XAndUpdate_sequence.copy()
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1,run2_nanoAOD_LowPU:
     modifier.toReplaceWith(electronSequence, _withTo106XAndUpdate_sequence)
 

--- a/PhysicsTools/NanoAOD/python/nanoTP_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoTP_cff.py
@@ -53,6 +53,16 @@ nanotpSequenceMC = cms.Sequence(
         triggerObjectTables + l1bits
         )
 
+nanoAOD_addLowPUEleInfo_switch = cms.PSet(
+    nanoAOD_addLowPUEleInfo_switch = cms.untracked.bool(False),
+)
+run2_nanoAOD_LowPU.toModify(nanoAOD_addLowPUEleInfo_switch, nanoAOD_addLowPUEleInfo_switch = cms.untracked.bool(True))
+if nanoAOD_addLowPUEleInfo_switch.nanoAOD_addLowPUEleInfo_switch:
+    # add low PU electron ID variables
+    from PhysicsTools.NanoAOD.electronTP_LowPU_cff import *
+    nanotpSequence.insert(nanotpSequence.index(muonTable) + 1,  electronTPSequence_LowPU)
+    nanotpSequenceMC.insert(nanotpSequenceMC.index(muonTable) + 1,  electronTPSequenceMC_LowPU)
+
 def customizeNANOTP(process):
     finalIsolatedTracks.finalLeptons = ["finalLooseMuons"]
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -123,7 +123,7 @@ nanoSequenceOnlyData = cms.Sequence(protonTables + lhcInfoTable)
 
 nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequenceOnlyFullSim)
 
-( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(nanoSequence, nanoSequence.copyAndExclude([nanoSequenceOnlyData]))
+( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel | run2_nanoAOD_LowPU).toReplaceWith(nanoSequence, nanoSequence.copyAndExclude([nanoSequenceOnlyData]))
 
 nanoSequenceFS = cms.Sequence(genParticleSequence + genVertexTables + particleLevelSequence + nanoSequenceCommon + jetMC + muonMC + electronMC + lowPtElectronMC + photonMC + tauMC + boostedTauMC + metMC + ttbarCatMCProducers +  globalTablesMC + btagWeightTable + genWeightsTables + genVertexTable + genParticleTables + particleLevelTables + lheInfoTable  + ttbarCategoryTable )
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -66,6 +66,11 @@ def miniAOD_customizeCommon(process):
                                     addPFClusterIso = cms.bool(True),
                                     ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleEcalPFClusIso"),
                                     hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleHcalPFClusIso"))
+    from Configuration.Eras.Modifier_run2_nanoAOD_LowPU_cff import run2_nanoAOD_LowPU
+    run2_nanoAOD_LowPU.toModify(process.patElectrons,
+                                addPFClusterIso = cms.bool(True),
+                                ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleEcalPFClusIso"),
+                                hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleHcalPFClusIso"))
 
     #add puppi isolation in miniAOD
     process.patElectrons.addPuppiIsolation = cms.bool(True)
@@ -111,6 +116,15 @@ def miniAOD_customizeCommon(process):
                                     addPFClusterIso = cms.bool(True),
                                     ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "ootPhoEcalPFClusIso"),
                                     hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "ootPhoHcalPFClusIso"))
+    from Configuration.Eras.Modifier_run2_nanoAOD_LowPU_cff import run2_nanoAOD_LowPU
+    run2_nanoAOD_LowPU.toModify(process.patPhotons,
+                                addPFClusterIso = cms.bool(True),
+                                ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "phoEcalPFClusIso"),
+                                hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "phoHcalPFClusIso"))
+    run2_nanoAOD_LowPU.toModify(process.patOOTPhotons,
+                                addPFClusterIso = cms.bool(True),
+                                ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "ootPhoEcalPFClusIso"),
+                                hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "ootPhoHcalPFClusIso"))
 
 
     process.patPhotons.photonSource = cms.InputTag("reducedEgamma","reducedGedPhotons")
@@ -326,6 +340,11 @@ def miniAOD_customizeCommon(process):
     run2_miniAOD_94XFall17.toModify(process.electronMVAValueMapProducer,
                                      keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
                                      src = cms.InputTag("gedGsfElectronsFrom94XTo106X"))
+
+    run2_nanoAOD_LowPU.toModify(task, func=lambda t: t.add(process.gedGsfElectronsFrom94XTo106XTask))
+    run2_nanoAOD_LowPU.toModify(process.electronMVAValueMapProducer,
+                                 keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
+                                 src = cms.InputTag("gedGsfElectronsFrom94XTo106X"))
 
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection,None,False,task)

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -108,11 +108,41 @@ run2_miniAOD_94XFall17.toModify(
         )
     )
 
+from Configuration.Eras.Modifier_run2_nanoAOD_LowPU_cff import run2_nanoAOD_LowPU
+run2_nanoAOD_LowPU.toModify(
+    reducedEgamma,
+    photonFloatValueMapSources = cms.VInputTag(
+        cms.InputTag("photonEcalPFClusterIsolationProducer"),
+        cms.InputTag("photonHcalPFClusterIsolationProducer"),
+        ),
+    photonFloatValueMapOutput = cms.vstring(
+        "phoEcalPFClusIso",
+        "phoHcalPFClusIso",
+        ),
+    ootPhotonFloatValueMapSources = cms.VInputTag(
+        cms.InputTag("ootPhotonEcalPFClusterIsolationProducer"),
+        cms.InputTag("ootPhotonHcalPFClusterIsolationProducer"),
+        ),
+    ootPhotonFloatValueMapOutput = cms.vstring(
+        "ootPhoEcalPFClusIso",
+        "ootPhoHcalPFClusIso",
+        ),
+    gsfElectronFloatValueMapSources = cms.VInputTag(
+        cms.InputTag("electronEcalPFClusterIsolationProducer"),
+        cms.InputTag("electronHcalPFClusterIsolationProducer"),
+        ),
+    gsfElectronFloatValueMapOutput = cms.vstring(
+        "eleEcalPFClusIso",
+        "eleHcalPFClusIso",
+        )
+    )
+
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_tools import calibrateReducedEgamma
+from Configuration.Eras.Modifier_run2_nanoAOD_LowPU_cff import run2_nanoAOD_LowPU
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 modifyReducedEGammaRun2MiniAOD = (
-    run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy | run2_miniAOD_UL).makeProcessModifier(calibrateReducedEgamma)
+    run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy | run2_miniAOD_UL | run2_nanoAOD_LowPU).makeProcessModifier(calibrateReducedEgamma)
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify( reducedEgamma, ootPhotons = cms.InputTag("") )


### PR DESCRIPTION
#### PR description:

Fix the electron energy scale corrections for Low PU (the original code applied the low PU correction first and then the regular 2017 corrections, which should be removed.)

Fix the TnP tree for LowPU dataset. The output TnP ntuples should work for the muon channel at Low PU now. 

All the changes are specified with `run2_nanoAOD_LowPU` modifier, so should not affect anything for the other eras.


