### PR TITLE
change failIfInvalidXML to false to prevent bkg sample crashing

### DIFF
--- a/PhysicsTools/NanoAOD/python/genWeights_cff.py
+++ b/PhysicsTools/NanoAOD/python/genWeights_cff.py
@@ -7,6 +7,8 @@ genWeightsNano.weightProductLabels = ["genWeights"]
 
 lheWeightsNano = lheWeights.clone()
 lheWeightsNano.weightProductLabels = ["lheWeights"]
+# fix for crashing for bkg samples
+lheWeightsNano.failIfInvalidXML = cms.untracked.bool(False)
 
 genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     lheWeightPrecision = cms.int32(14),


### PR DESCRIPTION
changing the default flag of `failIfInvalidXML` to `False` to prevent crashing on some of the background samples.

tested and confirmed the background samples run fine now.