### PR TITLE
Remove pt cut for track refit

### DIFF
--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -124,7 +124,7 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff import *
 tracksfrommuons = cms.EDProducer("TrackProducerFromPatMuons",
                               src = cms.InputTag("linkedObjects", "muons"),
                               innerTrackOnly = cms.bool(False),
-                              ptMin = cms.double(8.),
+                              ptMin = cms.double(-1.),
                               )
 
 trackrefit = cms.EDProducer('ResidualGlobalCorrectionMakerG4e',


### PR DESCRIPTION
Remove the pt cut for the track refit in order to facilitate calibration cross checks with the Z