### PR TITLE
Lowered track and muon pt cuts to 8 GeV

### DIFF
--- a/PhysicsTools/NanoAOD/python/generalTracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/generalTracks_cff.py
@@ -3,9 +3,9 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 generalTrackTable = cms.EDProducer("SimpleTrackFlatTableProducer",
     src = cms.InputTag("generalTracks"),
-    cut = cms.string("pt > 10"), # filtered already above
+    cut = cms.string("pt > 8"), # filtered already above
     name = cms.string("Track"),
-    doc  = cms.string("General tracks with pt > 10 GeV"),
+    doc  = cms.string("General tracks with pt > 8 GeV"),
     singleton = cms.bool(False), # the number of entries is variable
     extension = cms.bool(False), # this is the main table for the muons
     variables = cms.PSet(P3Vars,


### PR DESCRIPTION
Lowered pt cut for objects saved into ntuples. Can be useful for future studies.
File size increases by ~1%.