### PR TITLE
Bug fix for NANOTP production

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoTP_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoTP_cff.py
@@ -75,6 +75,8 @@ def customizeNANOTP(process):
 
     muonTable.src = "linkedMuons"
 
+    process.vertexTable.svSrc = "slimmedSecondaryVertices"
+
     muonvtxagniso04.muonInputTag = muonTable.src
     muonvtxagniso03.muonInputTag = muonTable.src
 


### PR DESCRIPTION
As per title, introduce a minimal edit in nanoTP_cff.py to allow the NANOAODs for TNP to be produced. At the moment the extra variables for the secondary vertex are still in the nTuples, but these are never used for TNP.